### PR TITLE
PixelMouse: local Next.js CRM MVP (Prisma + SQLite) with assisted WhatsApp campaigns

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL="file:./dev.db"
+CHROME_PATH="C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+.env
+*.log
+prisma/dev.db
+prisma/dev.db-journal

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 *.log
 prisma/dev.db
 prisma/dev.db-journal
+dist
+release

--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
-# PixelMouse (Local-Only)
+# PixelMouse (Local-Only CRM + WhatsApp Assistant)
 
-PixelMouse is a local-only CRM + templates + campaign queue assistant for WhatsApp Web.
+PixelMouse is a **local-only** CRM for Windows that can run in browser (`http://localhost:3000`) or as a **portable EXE desktop app**.
 
-## Stack
-- Next.js App Router + TypeScript + TailwindCSS
-- Prisma + SQLite
-- Zod validation
+## What this app does safely
+- ✅ Personal CRM (accounts, contacts, tags, templates, campaigns, rules)
+- ✅ Assisted sending for WhatsApp Web (manual click in WhatsApp required)
+- ✅ Multi-account support using Chrome profile directories (`Default`, `Profile 2`, etc.)
+- ❌ No bulk auto-send
+- ❌ No WhatsApp DOM automation / bypass
 
-## Safety design
-- **No bulk auto-send** and **no WhatsApp DOM automation**.
-- Campaigns are **assisted sending**:
-  1. PixelMouse opens WhatsApp Web with prefilled message.
-  2. User manually clicks Send in WhatsApp.
-  3. User clicks "Mark as Sent" in PixelMouse.
+---
 
-## Prerequisites
+## 1) Requirements
+- Windows 10/11
 - Node.js 18+
-- Windows + Google Chrome
+- Google Chrome
 
-## Setup
+---
+
+## 2) Quick start (web mode)
+
 ```bash
 npm install
 cp .env.example .env
@@ -26,38 +27,112 @@ npx prisma generate
 npx prisma migrate dev --name init
 npm run dev
 ```
-Open http://localhost:3000
 
-## Environment variables
+Open: `http://localhost:3000`
+
+---
+
+## 3) Environment variables (`.env`)
+
 ```env
 DATABASE_URL="file:./dev.db"
 CHROME_PATH="C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
 ```
-If `CHROME_PATH` is missing, PixelMouse falls back to common Chrome location.
 
-## Multiple WhatsApp accounts with Chrome profiles
-1. In Chrome, create profiles (Default, Profile 2, etc.).
-2. Open each profile once and login to WhatsApp Web in that profile.
-3. In `/accounts`, create one account per profile with matching `chromeProfileDir`.
-4. Use **Test launch** to verify profile opens WhatsApp Web session.
+Fallback Chrome path is used if `CHROME_PATH` is not configured.
 
-## Linking WhatsApp account to a profile
-- Launch Chrome profile manually if needed:
-  - `chrome.exe --profile-directory="Default" https://web.whatsapp.com`
-- Scan QR once for that profile.
-- Future launches from PixelMouse reuse that session.
+---
 
-## CSV import/export
-- Import columns: `name,phoneE164,notes,status,tags`
-- `tags` can use `|` separator, e.g. `buyer|vip`.
+## 4) Multi-account WhatsApp setup (Chrome profiles)
 
-## Campaign run flow
-- Create campaign with account + delay range + contacts + message lines.
-- Run campaign queue.
-- Click **Open WhatsApp Web** (opens selected profile + prefilled text).
-- Manually send in WhatsApp.
-- Click **Mark as Sent** or **Skip**.
-- Random cooldown is shown before next send action.
+1. Create Chrome profiles (Default, Profile 2, Profile 3...)
+2. Open WhatsApp Web once in each profile and scan QR.
+3. In **Accounts** page, create an account per profile and set the exact `chromeProfileDir`.
+4. Use **Test launch** to verify the selected profile opens WhatsApp Web.
 
-## Offline behavior
-Everything is local and offline except WhatsApp Web access itself.
+Manual test command:
+```powershell
+"C:\Program Files\Google\Chrome\Application\chrome.exe" --profile-directory="Profile 2" "https://web.whatsapp.com"
+```
+
+---
+
+## 5) Portable EXE build (what you asked)
+
+This creates a single Windows portable executable (no installer required):
+
+```powershell
+npm install
+npx prisma generate
+npm run build:desktop
+npm run dist:portable
+```
+
+Output file:
+- `dist/PixelMouse Portable <version>.exe`
+
+You can copy that EXE to another Windows PC and run it directly.
+
+### Optional one-command script
+PowerShell script included:
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\build-portable.ps1
+```
+
+---
+
+## 6) Desktop mode for development
+
+Runs Electron + local Next server automatically:
+
+```bash
+npm run dev:desktop
+```
+
+---
+
+## 7) Using PixelMouse (step-by-step)
+
+### Accounts
+- Create account with `name`, optional `phoneE164`, and `chromeProfileDir`.
+- Press **Test launch**.
+
+### Contacts
+- Create contacts manually or import CSV.
+- CSV headers: `name,phoneE164,notes,status,tags`
+- Tags in CSV use `|` separator (e.g. `buyer|vip`).
+- Use filters by tag/status and export CSV when needed.
+
+### Tags
+- Create/delete tags.
+
+### Templates
+- Create template bodies with variables like `{nombre}`, `{telefono}`, `{proyecto}`, `{precio_desde}`.
+
+### Campaigns
+1. Create campaign (account + min/max delay + contacts + ordered message lines).
+2. Open run screen.
+3. Click **Open WhatsApp Web** (prefills message with contact data).
+4. Manually send inside WhatsApp Web.
+5. Click **Mark as Sent** in PixelMouse.
+6. Wait for random cooldown before next item.
+
+### Rules + Helper
+- Create keyword rules (contains/starts/ends/exact).
+- In Helper page, paste incoming message and select contact.
+- App suggests top matching responses.
+- Copy response manually or open chat with prefilled suggestion.
+
+---
+
+## 8) Local-only architecture
+- DB: SQLite (`prisma/dev.db`)
+- ORM: Prisma
+- App/API: Next.js route handlers + server actions
+- Desktop wrapper: Electron
+- No external backend required.
+
+---
+
+## 9) Safety reminder
+PixelMouse is intentionally designed for **assisted/manual sending only**. User must manually confirm each message send in WhatsApp Web.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# PixelMouse (Local-Only)
+
+PixelMouse is a local-only CRM + templates + campaign queue assistant for WhatsApp Web.
+
+## Stack
+- Next.js App Router + TypeScript + TailwindCSS
+- Prisma + SQLite
+- Zod validation
+
+## Safety design
+- **No bulk auto-send** and **no WhatsApp DOM automation**.
+- Campaigns are **assisted sending**:
+  1. PixelMouse opens WhatsApp Web with prefilled message.
+  2. User manually clicks Send in WhatsApp.
+  3. User clicks "Mark as Sent" in PixelMouse.
+
+## Prerequisites
+- Node.js 18+
+- Windows + Google Chrome
+
+## Setup
+```bash
+npm install
+cp .env.example .env
+npx prisma generate
+npx prisma migrate dev --name init
+npm run dev
+```
+Open http://localhost:3000
+
+## Environment variables
+```env
+DATABASE_URL="file:./dev.db"
+CHROME_PATH="C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
+```
+If `CHROME_PATH` is missing, PixelMouse falls back to common Chrome location.
+
+## Multiple WhatsApp accounts with Chrome profiles
+1. In Chrome, create profiles (Default, Profile 2, etc.).
+2. Open each profile once and login to WhatsApp Web in that profile.
+3. In `/accounts`, create one account per profile with matching `chromeProfileDir`.
+4. Use **Test launch** to verify profile opens WhatsApp Web session.
+
+## Linking WhatsApp account to a profile
+- Launch Chrome profile manually if needed:
+  - `chrome.exe --profile-directory="Default" https://web.whatsapp.com`
+- Scan QR once for that profile.
+- Future launches from PixelMouse reuse that session.
+
+## CSV import/export
+- Import columns: `name,phoneE164,notes,status,tags`
+- `tags` can use `|` separator, e.g. `buyer|vip`.
+
+## Campaign run flow
+- Create campaign with account + delay range + contacts + message lines.
+- Run campaign queue.
+- Click **Open WhatsApp Web** (opens selected profile + prefilled text).
+- Manually send in WhatsApp.
+- Click **Mark as Sent** or **Skip**.
+- Random cooldown is shown before next send action.
+
+## Offline behavior
+Everything is local and offline except WhatsApp Web access itself.

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,0 +1,96 @@
+const { app, BrowserWindow, dialog, shell } = require('electron');
+const path = require('path');
+const { spawn } = require('child_process');
+const http = require('http');
+
+const APP_PORT = 3000;
+const APP_URL = `http://127.0.0.1:${APP_PORT}`;
+let serverProcess = null;
+
+function waitForServer(url, timeoutMs = 90000) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      const req = http.get(url, (res) => {
+        res.resume();
+        resolve();
+      });
+      req.on('error', () => {
+        if (Date.now() - start > timeoutMs) {
+          reject(new Error('Next.js server startup timeout'));
+          return;
+        }
+        setTimeout(check, 500);
+      });
+    };
+    check();
+  });
+}
+
+function startNextServer() {
+  if (serverProcess) return;
+
+  const appPath = app.getAppPath();
+  const nextBin = path.join(appPath, 'node_modules', 'next', 'dist', 'bin', 'next');
+  const isDev = !app.isPackaged;
+  const args = [nextBin, isDev ? 'dev' : 'start', '-p', String(APP_PORT)];
+
+  serverProcess = spawn(process.execPath, args, {
+    cwd: appPath,
+    env: {
+      ...process.env,
+      ELECTRON_RUN_AS_NODE: '1',
+      NODE_ENV: isDev ? 'development' : 'production'
+    },
+    stdio: 'pipe'
+  });
+
+  serverProcess.stdout.on('data', (d) => process.stdout.write(`[next] ${d}`));
+  serverProcess.stderr.on('data', (d) => process.stderr.write(`[next] ${d}`));
+  serverProcess.on('exit', (code) => {
+    console.log(`Next server exited: ${code}`);
+    serverProcess = null;
+  });
+}
+
+async function createWindow() {
+  startNextServer();
+
+  const win = new BrowserWindow({
+    width: 1320,
+    height: 860,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      preload: path.join(__dirname, 'preload.cjs')
+    }
+  });
+
+  try {
+    await waitForServer(APP_URL);
+    await win.loadURL(APP_URL);
+  } catch (error) {
+    dialog.showErrorBox(
+      'PixelMouse startup failed',
+      `Could not start local server on ${APP_URL}.\n\n${error.message}`
+    );
+    app.quit();
+  }
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url);
+    return { action: 'deny' };
+  });
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+app.on('before-quit', () => {
+  if (serverProcess) {
+    serverProcess.kill('SIGTERM');
+  }
+});

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,0 +1,1 @@
+// Intentionally empty for now. Kept for secure future IPC additions.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '2mb'
+    }
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "pixelmouse",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev --name init"
+  },
+  "dependencies": {
+    "@prisma/client": "5.20.0",
+    "clsx": "2.1.1",
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "zod": "3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.15",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.20",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
+    "postcss": "8.4.41",
+    "prisma": "5.20.0",
+    "tailwindcss": "3.4.10",
+    "typescript": "5.5.4"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,14 +1,19 @@
 {
   "name": "pixelmouse",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
+  "main": "electron/main.cjs",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3000",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 3000",
     "lint": "next lint",
     "prisma:generate": "prisma generate",
-    "prisma:migrate": "prisma migrate dev --name init"
+    "prisma:migrate": "prisma migrate dev --name init",
+    "dev:desktop": "concurrently \"npm run dev\" \"wait-on tcp:3000 && electron .\"",
+    "build:desktop": "npm run prisma:generate && npm run build",
+    "dist:portable": "npm run build:desktop && electron-builder --win portable",
+    "dist:dir": "npm run build:desktop && electron-builder --dir"
   },
   "dependencies": {
     "@prisma/client": "5.20.0",
@@ -23,11 +28,45 @@
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "autoprefixer": "10.4.20",
+    "concurrently": "9.0.1",
+    "electron": "31.7.7",
+    "electron-builder": "24.13.3",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.5",
     "postcss": "8.4.41",
     "prisma": "5.20.0",
     "tailwindcss": "3.4.10",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "wait-on": "8.0.1"
+  },
+  "build": {
+    "appId": "com.pixelmouse.app",
+    "productName": "PixelMouse",
+    "asar": true,
+    "files": [
+      ".next/**/*",
+      "public/**/*",
+      "prisma/**/*",
+      "src/**/*",
+      "electron/**/*",
+      "package.json",
+      "next.config.mjs",
+      "postcss.config.mjs",
+      "tailwind.config.ts",
+      "tsconfig.json"
+    ],
+    "extraMetadata": {
+      "main": "electron/main.cjs"
+    },
+    "win": {
+      "target": [
+        {
+          "target": "portable",
+          "arch": [
+            "x64"
+          ]
+        }
+      ]
+    }
   }
 }

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/prisma/migrations/0001_init/migration.sql
+++ b/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,87 @@
+-- CreateTable
+CREATE TABLE "Account" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "phoneE164" TEXT,
+    "chromeProfileDir" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE "Contact" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "phoneE164" TEXT NOT NULL,
+    "notes" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'NUEVO',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+CREATE UNIQUE INDEX "Contact_phoneE164_key" ON "Contact"("phoneE164");
+CREATE TABLE "Tag" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL
+);
+CREATE UNIQUE INDEX "Tag_name_key" ON "Tag"("name");
+CREATE TABLE "ContactTag" (
+    "contactId" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+    PRIMARY KEY ("contactId", "tagId"),
+    CONSTRAINT "ContactTag_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "Contact" ("id") ON DELETE CASCADE,
+    CONSTRAINT "ContactTag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag" ("id") ON DELETE CASCADE
+);
+CREATE TABLE "Template" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+CREATE TABLE "Campaign" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "minDelaySec" INTEGER NOT NULL,
+    "maxDelaySec" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Campaign_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "Account" ("id") ON DELETE RESTRICT
+);
+CREATE TABLE "CampaignMessage" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "campaignId" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "body" TEXT NOT NULL,
+    CONSTRAINT "CampaignMessage_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "Campaign" ("id") ON DELETE CASCADE
+);
+CREATE TABLE "CampaignTarget" (
+    "campaignId" TEXT NOT NULL,
+    "contactId" TEXT NOT NULL,
+    PRIMARY KEY ("campaignId", "contactId"),
+    CONSTRAINT "CampaignTarget_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "Campaign" ("id") ON DELETE CASCADE,
+    CONSTRAINT "CampaignTarget_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "Contact" ("id") ON DELETE CASCADE
+);
+CREATE TABLE "CampaignRun" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "campaignId" TEXT NOT NULL,
+    "startedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "finishedAt" DATETIME,
+    "status" TEXT NOT NULL DEFAULT 'DRAFT',
+    CONSTRAINT "CampaignRun_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "Campaign" ("id") ON DELETE CASCADE
+);
+CREATE TABLE "CampaignRunItem" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "runId" TEXT NOT NULL,
+    "contactId" TEXT NOT NULL,
+    "state" TEXT NOT NULL DEFAULT 'PENDING',
+    "openedAt" DATETIME,
+    "sentAt" DATETIME,
+    CONSTRAINT "CampaignRunItem_runId_fkey" FOREIGN KEY ("runId") REFERENCES "CampaignRun" ("id") ON DELETE CASCADE,
+    CONSTRAINT "CampaignRunItem_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "Contact" ("id") ON DELETE CASCADE
+);
+CREATE TABLE "Rule" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "keyword" TEXT NOT NULL,
+    "matchType" TEXT NOT NULL DEFAULT 'CONTAINS',
+    "response" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,146 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+enum ContactStatus {
+  NUEVO
+  CONTACTADO
+  CALIFICADO
+  CITA_AGENDADA
+  CITA_HECHA
+  PROPUESTA
+  RESERVA
+  CIERRE
+  PERDIDO
+}
+
+enum CampaignRunStatus {
+  DRAFT
+  RUNNING
+  DONE
+}
+
+enum CampaignRunItemState {
+  PENDING
+  OPENED
+  SENT
+  SKIPPED
+}
+
+enum RuleMatchType {
+  CONTAINS
+  STARTS_WITH
+  ENDS_WITH
+  EXACT
+}
+
+model Account {
+  id               String     @id @default(cuid())
+  name             String
+  phoneE164        String?
+  chromeProfileDir String
+  isActive         Boolean    @default(true)
+  createdAt        DateTime   @default(now())
+  campaigns        Campaign[]
+}
+
+model Contact {
+  id          String           @id @default(cuid())
+  name        String
+  phoneE164   String           @unique
+  notes       String?
+  status      ContactStatus    @default(NUEVO)
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+  tags        ContactTag[]
+  targets     CampaignTarget[]
+  runItems    CampaignRunItem[]
+}
+
+model Tag {
+  id       String       @id @default(cuid())
+  name     String       @unique
+  contacts ContactTag[]
+}
+
+model ContactTag {
+  contactId String
+  tagId     String
+  contact   Contact @relation(fields: [contactId], references: [id], onDelete: Cascade)
+  tag       Tag     @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@id([contactId, tagId])
+}
+
+model Template {
+  id        String   @id @default(cuid())
+  name      String
+  body      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Campaign {
+  id           String            @id @default(cuid())
+  name         String
+  accountId    String
+  minDelaySec  Int
+  maxDelaySec  Int
+  createdAt    DateTime          @default(now())
+  account      Account           @relation(fields: [accountId], references: [id], onDelete: Restrict)
+  messages     CampaignMessage[]
+  targets      CampaignTarget[]
+  runs         CampaignRun[]
+}
+
+model CampaignMessage {
+  id         String   @id @default(cuid())
+  campaignId String
+  order      Int
+  body       String
+  campaign   Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+}
+
+model CampaignTarget {
+  campaignId String
+  contactId  String
+  campaign   Campaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  contact    Contact  @relation(fields: [contactId], references: [id], onDelete: Cascade)
+
+  @@id([campaignId, contactId])
+}
+
+model CampaignRun {
+  id         String           @id @default(cuid())
+  campaignId String
+  startedAt  DateTime         @default(now())
+  finishedAt DateTime?
+  status     CampaignRunStatus @default(DRAFT)
+  campaign   Campaign         @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  items      CampaignRunItem[]
+}
+
+model CampaignRunItem {
+  id        String              @id @default(cuid())
+  runId     String
+  contactId String
+  state     CampaignRunItemState @default(PENDING)
+  openedAt  DateTime?
+  sentAt    DateTime?
+  run       CampaignRun         @relation(fields: [runId], references: [id], onDelete: Cascade)
+  contact   Contact             @relation(fields: [contactId], references: [id], onDelete: Cascade)
+}
+
+model Rule {
+  id        String        @id @default(cuid())
+  name      String
+  keyword   String
+  matchType RuleMatchType @default(CONTAINS)
+  response  String
+  enabled   Boolean       @default(true)
+}

--- a/scripts/build-portable.ps1
+++ b/scripts/build-portable.ps1
@@ -1,0 +1,14 @@
+Write-Host "[PixelMouse] Installing dependencies..."
+npm install
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "[PixelMouse] Generating Prisma client..."
+npx prisma generate
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "[PixelMouse] Applying migrations..."
+npx prisma migrate deploy
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "[PixelMouse] Building portable EXE..."
+npm run dist:portable

--- a/scripts/run-portable-dev.bat
+++ b/scripts/run-portable-dev.bat
@@ -1,0 +1,17 @@
+@echo off
+setlocal
+
+where node >nul 2>&1
+if %ERRORLEVEL% neq 0 (
+  echo Node.js is required. Install Node 18+ and try again.
+  exit /b 1
+)
+
+if not exist node_modules (
+  echo Installing dependencies...
+  call npm install
+  if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
+)
+
+echo Starting PixelMouse desktop mode...
+call npm run dev:desktop

--- a/src/app/accounts/page.tsx
+++ b/src/app/accounts/page.tsx
@@ -1,0 +1,56 @@
+import { prisma } from '@/lib/prisma';
+import { revalidatePath } from 'next/cache';
+import { accountSchema } from '@/lib/validators';
+
+async function createAccount(formData: FormData) {
+  'use server';
+  const parsed = accountSchema.parse({
+    name: String(formData.get('name') || ''),
+    phoneE164: String(formData.get('phoneE164') || ''),
+    chromeProfileDir: String(formData.get('chromeProfileDir') || 'Default')
+  });
+  await prisma.account.create({
+    data: { ...parsed, phoneE164: parsed.phoneE164 || null, isActive: Boolean(formData.get('isActive')) }
+  });
+  revalidatePath('/accounts');
+}
+
+async function deleteAccount(formData: FormData) {
+  'use server';
+  await prisma.account.delete({ where: { id: String(formData.get('id')) } });
+  revalidatePath('/accounts');
+}
+
+export default async function AccountsPage() {
+  const accounts = await prisma.account.findMany({ orderBy: { createdAt: 'desc' } });
+  return (
+    <div className="space-y-6">
+      <h1 className="text-xl font-semibold">Accounts</h1>
+      <form action={createAccount} className="grid grid-cols-4 gap-2 rounded bg-white p-3">
+        <input name="name" placeholder="Name" required />
+        <input name="phoneE164" placeholder="+1555000111" />
+        <input name="chromeProfileDir" placeholder="Default / Profile 2" required defaultValue="Default" />
+        <label className="flex items-center gap-2"><input type="checkbox" name="isActive" defaultChecked /> Active</label>
+        <button className="col-span-4 w-fit" type="submit">Create</button>
+      </form>
+
+      <div className="space-y-2">
+        {accounts.map((acc) => (
+          <div key={acc.id} className="flex items-center justify-between rounded bg-white p-3">
+            <div>
+              <p className="font-medium">{acc.name} ({acc.chromeProfileDir})</p>
+              <p className="text-sm text-slate-500">{acc.phoneE164 || 'No phone'}</p>
+            </div>
+            <div className="flex gap-2">
+              <a href={`/api/accounts/${acc.id}/launch`} className="rounded bg-blue-600 px-3 py-1 text-white">Test launch</a>
+              <form action={deleteAccount}>
+                <input type="hidden" name="id" value={acc.id} />
+                <button type="submit">Delete</button>
+              </form>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/accounts/[id]/launch/route.ts
+++ b/src/app/api/accounts/[id]/launch/route.ts
@@ -1,0 +1,25 @@
+import { prisma } from '@/lib/prisma';
+import { spawn } from 'node:child_process';
+import { NextResponse } from 'next/server';
+
+function getChromePath() {
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  return 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe';
+}
+
+export async function GET(req: Request, { params }: { params: { id: string } }) {
+  const account = await prisma.account.findUnique({ where: { id: params.id } });
+  if (!account) return NextResponse.json({ error: 'Account not found' }, { status: 404 });
+
+  const url = new URL(req.url).searchParams.get('url') || 'https://web.whatsapp.com';
+  const chromePath = getChromePath();
+  const args = [`--profile-directory=${account.chromeProfileDir}`, url];
+
+  try {
+    const child = spawn(chromePath, args, { detached: true, stdio: 'ignore' });
+    child.unref();
+    return NextResponse.json({ ok: true, url });
+  } catch {
+    return NextResponse.json({ ok: false, url, fallback: `Run: "${chromePath}" --profile-directory="${account.chromeProfileDir}" "${url}"` }, { status: 500 });
+  }
+}

--- a/src/app/api/campaign-runs/[runId]/items/[itemId]/route.ts
+++ b/src/app/api/campaign-runs/[runId]/items/[itemId]/route.ts
@@ -1,0 +1,17 @@
+import { prisma } from '@/lib/prisma';
+import { NextResponse } from 'next/server';
+
+export async function PATCH(req: Request, { params }: { params: { runId: string; itemId: string } }) {
+  const body = await req.json();
+  const state = body.state as 'OPENED' | 'SENT' | 'SKIPPED';
+  const data: any = { state };
+  if (state === 'OPENED') data.openedAt = new Date();
+  if (state === 'SENT') data.sentAt = new Date();
+  await prisma.campaignRunItem.update({ where: { id: params.itemId }, data });
+
+  const pending = await prisma.campaignRunItem.count({ where: { runId: params.runId, state: 'PENDING' } });
+  if (pending === 0) {
+    await prisma.campaignRun.update({ where: { id: params.runId }, data: { status: 'DONE', finishedAt: new Date() } });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/campaigns/[id]/start/route.ts
+++ b/src/app/api/campaigns/[id]/start/route.ts
@@ -1,0 +1,15 @@
+import { prisma } from '@/lib/prisma';
+import { NextResponse } from 'next/server';
+
+export async function POST(_: Request, { params }: { params: { id: string } }) {
+  const campaign = await prisma.campaign.findUnique({ where: { id: params.id }, include: { targets: true } });
+  if (!campaign) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  const run = await prisma.campaignRun.create({
+    data: {
+      campaignId: campaign.id,
+      status: 'RUNNING',
+      items: { create: campaign.targets.map((t) => ({ contactId: t.contactId, state: 'PENDING' })) }
+    }
+  });
+  return NextResponse.json({ runId: run.id });
+}

--- a/src/app/api/contacts/export/route.ts
+++ b/src/app/api/contacts/export/route.ts
@@ -1,0 +1,17 @@
+import { prisma } from '@/lib/prisma';
+import { csvEscape } from '@/lib/utils';
+
+export async function GET() {
+  const contacts = await prisma.contact.findMany({ include: { tags: { include: { tag: true } } }, orderBy: { createdAt: 'asc' } });
+  const rows = ['name,phoneE164,notes,status,tags'];
+  for (const c of contacts) {
+    rows.push([
+      csvEscape(c.name),
+      csvEscape(c.phoneE164),
+      csvEscape(c.notes ?? ''),
+      c.status,
+      csvEscape(c.tags.map((t) => t.tag.name).join('|'))
+    ].join(','));
+  }
+  return new Response(rows.join('\n'), { headers: { 'content-type': 'text/csv', 'content-disposition': 'attachment; filename="contacts.csv"' } });
+}

--- a/src/app/api/contacts/import/route.ts
+++ b/src/app/api/contacts/import/route.ts
@@ -1,0 +1,35 @@
+import { prisma } from '@/lib/prisma';
+import { normalizePhone, parseCsvLine } from '@/lib/utils';
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const data = await req.formData();
+  const file = data.get('file');
+  if (!(file instanceof File)) return NextResponse.redirect(new URL('/contacts?import=0', req.url));
+  const text = await file.text();
+  const lines = text.split(/\r?\n/).filter(Boolean);
+  const header = parseCsvLine(lines[0]);
+  const idx = Object.fromEntries(header.map((h, i) => [h, i]));
+
+  for (const line of lines.slice(1)) {
+    const cols = parseCsvLine(line);
+    const phone = normalizePhone(cols[idx.phoneE164] || '');
+    if (!phone) continue;
+    const tags = (cols[idx.tags] || '').split('|').map((t) => t.trim()).filter(Boolean);
+
+    await prisma.contact.upsert({
+      where: { phoneE164: phone },
+      update: { name: cols[idx.name] || phone, notes: cols[idx.notes] || null, status: (cols[idx.status] as any) || 'NUEVO' },
+      create: { name: cols[idx.name] || phone, phoneE164: phone, notes: cols[idx.notes] || null, status: (cols[idx.status] as any) || 'NUEVO' }
+    });
+
+    const contact = await prisma.contact.findUnique({ where: { phoneE164: phone } });
+    if (!contact) continue;
+    for (const tagName of tags) {
+      const tag = await prisma.tag.upsert({ where: { name: tagName }, update: {}, create: { name: tagName } });
+      await prisma.contactTag.upsert({ where: { contactId_tagId: { contactId: contact.id, tagId: tag.id } }, update: {}, create: { contactId: contact.id, tagId: tag.id } });
+    }
+  }
+
+  return NextResponse.redirect(new URL('/contacts?import=1', req.url));
+}

--- a/src/app/campaigns/[id]/run/page.tsx
+++ b/src/app/campaigns/[id]/run/page.tsx
@@ -1,0 +1,41 @@
+import { prisma } from '@/lib/prisma';
+import { RunQueue } from '@/components/campaign/run-queue';
+
+export default async function RunPage({ params }: { params: { id: string } }) {
+  const campaign = await prisma.campaign.findUnique({
+    where: { id: params.id },
+    include: {
+      account: true,
+      messages: { orderBy: { order: 'asc' } },
+      runs: { orderBy: { startedAt: 'desc' }, take: 1, include: { items: { include: { contact: true } } } }
+    }
+  });
+  if (!campaign) return <div>Campaign not found.</div>;
+
+  let run = campaign.runs[0];
+  if (!run || run.status === 'DONE') {
+    const created = await prisma.campaignRun.create({
+      data: {
+        campaignId: campaign.id,
+        status: 'RUNNING',
+        items: { create: (await prisma.campaignTarget.findMany({ where: { campaignId: campaign.id } })).map((t) => ({ contactId: t.contactId, state: 'PENDING' })) }
+      },
+      include: { items: { include: { contact: true } } }
+    });
+    run = created;
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Run: {campaign.name}</h1>
+      <RunQueue
+        runId={run.id}
+        accountId={campaign.accountId}
+        minDelaySec={campaign.minDelaySec}
+        maxDelaySec={campaign.maxDelaySec}
+        messages={campaign.messages.map((m) => m.body)}
+        items={run.items as any}
+      />
+    </div>
+  );
+}

--- a/src/app/campaigns/page.tsx
+++ b/src/app/campaigns/page.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+import { statuses } from '@/lib/utils';
+import { revalidatePath } from 'next/cache';
+
+async function createCampaign(formData: FormData) {
+  'use server';
+  const contactIds = formData.getAll('contactIds').map(String);
+  const messages = String(formData.get('messages') || '').split('\n').map((s) => s.trim()).filter(Boolean);
+  const campaign = await prisma.campaign.create({
+    data: {
+      name: String(formData.get('name')),
+      accountId: String(formData.get('accountId')),
+      minDelaySec: Number(formData.get('minDelaySec') || 5),
+      maxDelaySec: Number(formData.get('maxDelaySec') || 20),
+      messages: { create: messages.map((body, idx) => ({ order: idx + 1, body })) },
+      targets: { create: contactIds.map((contactId) => ({ contactId })) }
+    }
+  });
+  revalidatePath('/campaigns');
+  revalidatePath(`/campaigns/${campaign.id}/run`);
+}
+
+export default async function CampaignsPage({ searchParams }: { searchParams?: { status?: string; tag?: string } }) {
+  const [accounts, contacts, tags, campaigns] = await Promise.all([
+    prisma.account.findMany({ where: { isActive: true } }),
+    prisma.contact.findMany({
+      where: {
+        ...(searchParams?.status ? { status: searchParams.status as any } : {}),
+        ...(searchParams?.tag ? { tags: { some: { tag: { name: searchParams.tag } } } } : {})
+      },
+      include: { tags: { include: { tag: true } } }
+    }),
+    prisma.tag.findMany(),
+    prisma.campaign.findMany({ include: { account: true, _count: { select: { targets: true } } }, orderBy: { createdAt: 'desc' } })
+  ]);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Campaigns</h1>
+      <form className="flex gap-2" method="GET">
+        <select name="status" defaultValue={searchParams?.status || ''}><option value="">All status</option>{statuses.map((s)=><option key={s}>{s}</option>)}</select>
+        <select name="tag" defaultValue={searchParams?.tag || ''}><option value="">All tags</option>{tags.map((t)=><option key={t.id}>{t.name}</option>)}</select>
+        <button type="submit">Filter contacts</button>
+      </form>
+      <form action={createCampaign} className="space-y-2 rounded bg-white p-3">
+        <input name="name" placeholder="Campaign name" required />
+        <select name="accountId" required><option value="">Select account</option>{accounts.map((a)=><option key={a.id} value={a.id}>{a.name} ({a.chromeProfileDir})</option>)}</select>
+        <div className="flex gap-2"><input type="number" name="minDelaySec" defaultValue={10} /><input type="number" name="maxDelaySec" defaultValue={30} /></div>
+        <textarea name="messages" rows={4} className="w-full" placeholder="One message line per sequence item" />
+        <div className="max-h-40 overflow-auto border p-2">
+          {contacts.map((c)=><label key={c.id} className="block"><input type="checkbox" name="contactIds" value={c.id} /> {c.name} · {c.phoneE164}</label>)}
+        </div>
+        <button>Create campaign</button>
+      </form>
+
+      {campaigns.map((c) => (
+        <div key={c.id} className="flex justify-between rounded bg-white p-3">
+          <div><p className="font-medium">{c.name}</p><p className="text-sm">{c.account.name} · contacts: {c._count.targets}</p></div>
+          <Link className="rounded bg-blue-600 px-3 py-1 text-white" href={`/campaigns/${c.id}/run`}>Run campaign</Link>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -1,0 +1,82 @@
+import { prisma } from '@/lib/prisma';
+import { statuses } from '@/lib/utils';
+import { revalidatePath } from 'next/cache';
+import { contactSchema } from '@/lib/validators';
+
+async function createContact(formData: FormData) {
+  'use server';
+  const tagNames = String(formData.get('tags') || '').split(',').map((t) => t.trim()).filter(Boolean);
+  const parsed = contactSchema.parse({
+    name: String(formData.get('name') || ''),
+    phoneE164: String(formData.get('phoneE164') || ''),
+    notes: String(formData.get('notes') || ''),
+    status: String(formData.get('status') || 'NUEVO')
+  });
+  await prisma.contact.create({
+    data: {
+      ...parsed,
+      notes: parsed.notes || null,
+      status: parsed.status as any,
+      tags: {
+        create: await Promise.all(tagNames.map(async (name) => {
+          const tag = await prisma.tag.upsert({ where: { name }, update: {}, create: { name } });
+          return { tagId: tag.id };
+        }))
+      }
+    }
+  });
+  revalidatePath('/contacts');
+}
+
+async function deleteContact(formData: FormData) {
+  'use server';
+  await prisma.contact.delete({ where: { id: String(formData.get('id')) } });
+  revalidatePath('/contacts');
+}
+
+export default async function ContactsPage({ searchParams }: { searchParams?: { status?: string; tag?: string; q?: string } }) {
+  const where: any = {};
+  if (searchParams?.status) where.status = searchParams.status;
+  if (searchParams?.q) where.name = { contains: searchParams.q };
+  if (searchParams?.tag) where.tags = { some: { tag: { name: searchParams.tag } } };
+
+  const [contacts, tags] = await Promise.all([
+    prisma.contact.findMany({ where, include: { tags: { include: { tag: true } } }, orderBy: { updatedAt: 'desc' } }),
+    prisma.tag.findMany({ orderBy: { name: 'asc' } })
+  ]);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Contacts</h1>
+      <form className="flex gap-2" method="GET">
+        <input name="q" placeholder="Search" defaultValue={searchParams?.q || ''} />
+        <select name="status" defaultValue={searchParams?.status || ''}><option value="">All statuses</option>{statuses.map((s)=><option key={s} value={s}>{s}</option>)}</select>
+        <select name="tag" defaultValue={searchParams?.tag || ''}><option value="">All tags</option>{tags.map((t)=><option key={t.id} value={t.name}>{t.name}</option>)}</select>
+        <button type="submit">Filter</button>
+        <a className="rounded bg-emerald-700 px-3 py-1 text-white" href="/api/contacts/export">Export CSV</a>
+      </form>
+      <form action="/api/contacts/import" method="POST" encType="multipart/form-data" className="flex gap-2 rounded bg-white p-3">
+        <input type="file" name="file" accept=".csv" required />
+        <button type="submit">Import CSV</button>
+      </form>
+      <form action={createContact} className="grid grid-cols-5 gap-2 rounded bg-white p-3">
+        <input name="name" placeholder="Name" required />
+        <input name="phoneE164" placeholder="+1555000111" required />
+        <select name="status">{statuses.map((s)=><option key={s} value={s}>{s}</option>)}</select>
+        <input name="tags" placeholder="vip,buyer" />
+        <input name="notes" placeholder="Notes" />
+        <button className="col-span-5 w-fit" type="submit">Add contact</button>
+      </form>
+
+      {contacts.map((c) => (
+        <div key={c.id} className="flex items-center justify-between rounded bg-white p-3">
+          <div>
+            <p className="font-medium">{c.name} · {c.phoneE164}</p>
+            <p className="text-sm">{c.status} · {c.tags.map((t) => t.tag.name).join(', ')}</p>
+          </div>
+          <form action={deleteContact}><input type="hidden" name="id" value={c.id} /><button>Delete</button></form>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-50 text-slate-900;
+}
+
+input, textarea, select {
+  @apply rounded border border-slate-300 px-2 py-1;
+}
+
+button {
+  @apply rounded bg-slate-900 px-3 py-1 text-white disabled:opacity-50;
+}

--- a/src/app/helper/page.tsx
+++ b/src/app/helper/page.tsx
@@ -1,0 +1,39 @@
+import { prisma } from '@/lib/prisma';
+
+function score(message: string, keyword: string, matchType: string) {
+  const msg = message.toLowerCase();
+  const key = keyword.toLowerCase();
+  if (matchType === 'EXACT') return msg === key ? 100 : 0;
+  if (matchType === 'STARTS_WITH') return msg.startsWith(key) ? 90 : 0;
+  if (matchType === 'ENDS_WITH') return msg.endsWith(key) ? 80 : 0;
+  return msg.includes(key) ? 70 : 0;
+}
+
+export default async function HelperPage({ searchParams }: { searchParams?: { message?: string; contactId?: string } }) {
+  const [contacts, rules] = await Promise.all([
+    prisma.contact.findMany({ orderBy: { name: 'asc' } }),
+    prisma.rule.findMany({ where: { enabled: true } })
+  ]);
+  const message = searchParams?.message || '';
+  const selected = contacts.find((c) => c.id === searchParams?.contactId);
+  const matches = rules
+    .map((r) => ({ ...r, score: score(message, r.keyword, r.matchType) }))
+    .filter((r) => r.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 5);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Rule helper</h1>
+      <form className="space-y-2 rounded bg-white p-3" method="GET">
+        <select name="contactId" defaultValue={searchParams?.contactId || ''}><option value="">Select contact</option>{contacts.map((c)=><option key={c.id} value={c.id}>{c.name}</option>)}</select>
+        <textarea name="message" defaultValue={message} rows={4} className="w-full" placeholder="Paste incoming message" />
+        <button type="submit">Suggest</button>
+      </form>
+      {matches.map((m) => {
+        const url = selected ? `https://web.whatsapp.com/send?phone=${selected.phoneE164.replace('+', '')}&text=${encodeURIComponent(m.response)}` : '#';
+        return <div key={m.id} className="rounded bg-white p-3"><p className="font-medium">{m.name}</p><p>{m.response}</p><div className="mt-2 flex gap-2"><span className="rounded border px-3 py-1">Copy response manually</span><a className="rounded bg-blue-600 px-3 py-1 text-white" href={url}>Open chat with response</a></div></div>;
+      })}
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import './globals.css';
+import { Navbar } from '@/components/navbar';
+import { LangProvider } from '@/components/lang-provider';
+
+export const metadata: Metadata = {
+  title: 'PixelMouse',
+  description: 'Local-only CRM for assisted WhatsApp Web sending.'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <LangProvider>
+          <Navbar />
+          <main className="mx-auto max-w-6xl p-4">{children}</main>
+        </LangProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">PixelMouse</h1>
+      <p>Local-only CRM + templates + assisted campaigns for WhatsApp Web.</p>
+      <Link href="/accounts" className="text-blue-600 underline">Start by creating an account</Link>
+    </div>
+  );
+}

--- a/src/app/rules/page.tsx
+++ b/src/app/rules/page.tsx
@@ -1,0 +1,35 @@
+import { prisma } from '@/lib/prisma';
+import { revalidatePath } from 'next/cache';
+
+async function createRule(formData: FormData) {
+  'use server';
+  await prisma.rule.create({ data: {
+    name: String(formData.get('name')),
+    keyword: String(formData.get('keyword')),
+    matchType: formData.get('matchType') as any,
+    response: String(formData.get('response')),
+    enabled: Boolean(formData.get('enabled'))
+  } });
+  revalidatePath('/rules');
+}
+
+async function deleteRule(formData: FormData) {
+  'use server';
+  await prisma.rule.delete({ where: { id: String(formData.get('id')) } });
+  revalidatePath('/rules');
+}
+
+export default async function RulesPage() {
+  const rules = await prisma.rule.findMany({ orderBy: { name: 'asc' } });
+  return <div className="space-y-4"><h1 className="text-xl font-semibold">Rules</h1>
+    <form action={createRule} className="grid grid-cols-5 gap-2 rounded bg-white p-3">
+      <input name="name" placeholder="Name" required />
+      <input name="keyword" placeholder="Keyword" required />
+      <select name="matchType"><option>CONTAINS</option><option>STARTS_WITH</option><option>ENDS_WITH</option><option>EXACT</option></select>
+      <input name="response" placeholder="Response" required />
+      <label className="flex items-center gap-2"><input type="checkbox" name="enabled" defaultChecked /> Enabled</label>
+      <button className="col-span-5 w-fit">Create</button>
+    </form>
+    {rules.map((r)=><div key={r.id} className="flex justify-between rounded bg-white p-3"><span>{r.name} · {r.matchType} · {r.keyword}</span><form action={deleteRule}><input type="hidden" name="id" value={r.id}/><button>Delete</button></form></div>)}
+  </div>;
+}

--- a/src/app/tags/page.tsx
+++ b/src/app/tags/page.tsx
@@ -1,0 +1,25 @@
+import { prisma } from '@/lib/prisma';
+import { revalidatePath } from 'next/cache';
+
+async function createTag(formData: FormData) {
+  'use server';
+  await prisma.tag.create({ data: { name: String(formData.get('name')) } });
+  revalidatePath('/tags');
+}
+
+async function deleteTag(formData: FormData) {
+  'use server';
+  await prisma.tag.delete({ where: { id: String(formData.get('id')) } });
+  revalidatePath('/tags');
+}
+
+export default async function TagsPage() {
+  const tags = await prisma.tag.findMany({ orderBy: { name: 'asc' } });
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Tags</h1>
+      <form action={createTag} className="flex gap-2"><input name="name" required /><button>Create</button></form>
+      {tags.map((t) => <div key={t.id} className="flex justify-between rounded bg-white p-3"><span>{t.name}</span><form action={deleteTag}><input type="hidden" name="id" value={t.id} /><button>Delete</button></form></div>)}
+    </div>
+  );
+}

--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -1,0 +1,32 @@
+import { prisma } from '@/lib/prisma';
+import { interpolateTemplate } from '@/lib/utils';
+import { revalidatePath } from 'next/cache';
+
+async function createTemplate(formData: FormData) {
+  'use server';
+  await prisma.template.create({ data: { name: String(formData.get('name')), body: String(formData.get('body')) } });
+  revalidatePath('/templates');
+}
+
+async function deleteTemplate(formData: FormData) {
+  'use server';
+  await prisma.template.delete({ where: { id: String(formData.get('id')) } });
+  revalidatePath('/templates');
+}
+
+export default async function TemplatesPage() {
+  const templates = await prisma.template.findMany({ orderBy: { updatedAt: 'desc' } });
+  const preview = interpolateTemplate('Hola {nombre}, proyecto {proyecto} desde {precio_desde}. Tel: {telefono}', { nombre: 'Ana', proyecto: 'Pixel', precio_desde: '120000', telefono: '+1555' });
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Templates</h1>
+      <div className="rounded bg-blue-50 p-3 text-sm">Preview sample: {preview}</div>
+      <form action={createTemplate} className="space-y-2 rounded bg-white p-3">
+        <input name="name" placeholder="Name" required />
+        <textarea name="body" placeholder="Hola {nombre}" required className="w-full" rows={4} />
+        <button>Create</button>
+      </form>
+      {templates.map((t)=><div key={t.id} className="rounded bg-white p-3"><p className="font-medium">{t.name}</p><pre className="whitespace-pre-wrap">{t.body}</pre><form action={deleteTemplate}><input type="hidden" name="id" value={t.id}/><button>Delete</button></form></div>)}
+    </div>
+  );
+}

--- a/src/components/campaign/run-queue.tsx
+++ b/src/components/campaign/run-queue.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+type Item = {
+  id: string;
+  state: 'PENDING' | 'OPENED' | 'SENT' | 'SKIPPED';
+  contact: { id: string; name: string; phoneE164: string; notes: string | null };
+};
+
+export function RunQueue({ runId, accountId, minDelaySec, maxDelaySec, messages, items }: { runId: string; accountId: string; minDelaySec: number; maxDelaySec: number; messages: string[]; items: Item[] }) {
+  const [currentItems, setCurrentItems] = useState(items);
+  const [cooldown, setCooldown] = useState(0);
+  const [tick, setTick] = useState(0);
+  const next = useMemo(() => currentItems.find((i) => i.state === 'PENDING'), [currentItems, tick]);
+
+  const message = useMemo(() => {
+    if (!next) return '';
+    return messages.join('\n').replace(/\{nombre\}/g, next.contact.name).replace(/\{telefono\}/g, next.contact.phoneE164);
+  }, [next, messages]);
+
+  async function updateState(itemId: string, state: 'OPENED' | 'SENT' | 'SKIPPED') {
+    await fetch(`/api/campaign-runs/${runId}/items/${itemId}`, { method: 'PATCH', body: JSON.stringify({ state }) });
+    setCurrentItems((prev) => prev.map((i) => (i.id === itemId ? { ...i, state } : i)));
+    if (state === 'SENT' || state === 'SKIPPED') {
+      const wait = Math.floor(Math.random() * (maxDelaySec - minDelaySec + 1)) + minDelaySec;
+      setCooldown(wait);
+      const interval = setInterval(() => setCooldown((v) => {
+        if (v <= 1) { clearInterval(interval); return 0; }
+        return v - 1;
+      }), 1000);
+      setTick((v) => v + 1);
+    }
+  }
+
+  async function openWhatsapp() {
+    if (!next) return;
+    const target = `https://web.whatsapp.com/send?phone=${next.contact.phoneE164.replace('+', '')}&text=${encodeURIComponent(message)}`;
+    await fetch(`/api/accounts/${accountId}/launch?url=${encodeURIComponent(target)}`);
+    await updateState(next.id, 'OPENED');
+  }
+
+  return (
+    <div className="space-y-3 rounded bg-white p-3">
+      <p>Pending: {currentItems.filter((i) => i.state === 'PENDING').length}</p>
+      {next ? (
+        <>
+          <p className="font-medium">Next: {next.contact.name} ({next.contact.phoneE164})</p>
+          <textarea value={message} readOnly rows={6} className="w-full" />
+          <div className="flex gap-2">
+            <button type="button" onClick={openWhatsapp}>Open WhatsApp Web</button>
+            <button type="button" onClick={() => updateState(next.id, 'SENT')} disabled={cooldown > 0}>Mark as Sent</button>
+            <button type="button" onClick={() => updateState(next.id, 'SKIPPED')} disabled={cooldown > 0}>Skip</button>
+          </div>
+          <p className="text-sm">Manual assisted sending only. Wait timer: {cooldown}s</p>
+        </>
+      ) : <p>Queue done.</p>}
+    </div>
+  );
+}

--- a/src/components/lang-provider.tsx
+++ b/src/components/lang-provider.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import { dictionary, type Lang } from '@/lib/i18n';
+
+type Context = {
+  lang: Lang;
+  setLang: (lang: Lang) => void;
+  t: typeof dictionary.en;
+};
+
+const LangContext = createContext<Context | null>(null);
+
+export function LangProvider({ children }: { children: ReactNode }) {
+  const [lang, setLang] = useState<Lang>('es');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('pixelmouse-lang') as Lang | null;
+    if (stored && (stored === 'es' || stored === 'en')) {
+      setLang(stored);
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      lang,
+      setLang: (newLang: Lang) => {
+        localStorage.setItem('pixelmouse-lang', newLang);
+        setLang(newLang);
+      },
+      t: dictionary[lang]
+    }),
+    [lang]
+  );
+
+  return <LangContext.Provider value={value}>{children}</LangContext.Provider>;
+}
+
+export function useLang() {
+  const ctx = useContext(LangContext);
+  if (!ctx) throw new Error('useLang must be used inside LangProvider');
+  return ctx;
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useLang } from './lang-provider';
+
+const links = [
+  { href: '/accounts', key: 'accounts' },
+  { href: '/contacts', key: 'contacts' },
+  { href: '/tags', key: 'tags' },
+  { href: '/templates', key: 'templates' },
+  { href: '/campaigns', key: 'campaigns' },
+  { href: '/rules', key: 'rules' },
+  { href: '/helper', key: 'helper' }
+] as const;
+
+export function Navbar() {
+  const pathname = usePathname();
+  const { t, lang, setLang } = useLang();
+  return (
+    <header className="border-b bg-white">
+      <div className="mx-auto flex max-w-6xl items-center justify-between p-4">
+        <Link href="/" className="font-bold">{t.appName}</Link>
+        <nav className="flex gap-3 text-sm">
+          {links.map((link) => (
+            <Link key={link.href} href={link.href} className={pathname.startsWith(link.href) ? 'font-semibold text-blue-600' : ''}>
+              {t[link.key]}
+            </Link>
+          ))}
+        </nav>
+        <button className="rounded border px-2 py-1 text-xs" onClick={() => setLang(lang === 'es' ? 'en' : 'es')}>
+          {lang.toUpperCase()}
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,24 @@
+export const dictionary = {
+  en: {
+    appName: 'PixelMouse',
+    accounts: 'Accounts',
+    contacts: 'Contacts',
+    tags: 'Tags',
+    templates: 'Templates',
+    campaigns: 'Campaigns',
+    rules: 'Rules',
+    helper: 'Helper'
+  },
+  es: {
+    appName: 'PixelMouse',
+    accounts: 'Cuentas',
+    contacts: 'Contactos',
+    tags: 'Etiquetas',
+    templates: 'Plantillas',
+    campaigns: 'Campañas',
+    rules: 'Reglas',
+    helper: 'Asistente'
+  }
+} as const;
+
+export type Lang = keyof typeof dictionary;

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,40 @@
+export const statuses = ['NUEVO','CONTACTADO','CALIFICADO','CITA_AGENDADA','CITA_HECHA','PROPUESTA','RESERVA','CIERRE','PERDIDO'] as const;
+
+export function interpolateTemplate(body: string, values: Record<string, string | undefined>) {
+  return body.replace(/\{(.*?)\}/g, (_, key: string) => values[key.trim()] ?? '');
+}
+
+export function normalizePhone(phone: string) {
+  return phone.trim().replace(/\s+/g, '');
+}
+
+export function csvEscape(value: string) {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export function parseCsvLine(line: string) {
+  const out: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const c = line[i];
+    if (c === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (c === ',' && !inQuotes) {
+      out.push(current);
+      current = '';
+    } else {
+      current += c;
+    }
+  }
+  out.push(current);
+  return out;
+}

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const accountSchema = z.object({
+  name: z.string().min(1),
+  phoneE164: z.string().optional(),
+  chromeProfileDir: z.string().min(1)
+});
+
+export const contactSchema = z.object({
+  name: z.string().min(1),
+  phoneE164: z.string().min(3),
+  notes: z.string().optional(),
+  status: z.string()
+});

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/pages/**/*.{js,ts,jsx,tsx,mdx}', './src/components/**/*.{js,ts,jsx,tsx,mdx}', './src/app/**/*.{js,ts,jsx,tsx,mdx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a local-only personal CRM that integrates templates, campaigns and a rule-based helper for drafting WhatsApp Web messages while preventing any automatic sending or DOM automation.
- Support multiple WhatsApp accounts by launching Windows Chrome with different profile directories so each account keeps its own WhatsApp Web session.
- Keep everything self-hosted with a local SQLite DB (Prisma) and a lightweight Next.js (App Router) + TypeScript + Tailwind front-end.

### Description
- Scaffolded a Next.js app (App Router) with TypeScript and Tailwind and added a simple app shell, navbar and an ES/EN in-app language toggle persisted to `localStorage` (`src/components/lang-provider.tsx`, `src/components/navbar.tsx`, `src/lib/i18n.ts`).
- Added Prisma schema and initial SQL migration for `Account`, `Contact`, `Tag`, `ContactTag`, `Template`, `Campaign` and related run/items, and `Rule` enums/models (`prisma/schema.prisma`, `prisma/migrations/0001_init/migration.sql`).
- Implemented CRUD pages and server actions/route handlers for Accounts, Contacts (CSV import/export), Tags, Templates (variable preview), Campaigns, Campaign run queue (assisted sending), Rules and a Rule helper page for suggested responses (`src/app/*`, `src/app/api/*`).
- Implemented assisted campaign flow with manual steps only: a run queue component that generates prefilled WhatsApp URLs, opens Chrome with `--profile-directory=<dir>` via a launch route, shows a randomized cooldown between sends and requires the user to click `Mark as Sent` (no auto-send) (`src/components/campaign/run-queue.tsx`, `src/app/api/accounts/[id]/launch/route.ts`).
- Utility helpers for CSV parsing/escaping, phone normalization and template interpolation and Zod validators for basic form validation (`src/lib/utils.ts`, `src/lib/validators.ts`).
- Project docs and environment template added including `CHROME_PATH` guidance and commands to create/migrate the local DB (`README.md`, `.env.example`).

### Testing
- Attempted `npm install` to perform a local dependency install, but it failed due to restricted npm registry access (HTTP 403) so runtime verification could not be completed.
- Attempted a quick end-to-end page load with Playwright against `http://localhost:3000`, but it returned `ERR_EMPTY_RESPONSE` because the dev server could not be started without dependencies.
- Database migration generation and runtime checks (`npx prisma generate` / `npx prisma migrate dev`) were not executed in this environment due to the `npm install` failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa348aa9648320aad2d710cd159abb)